### PR TITLE
made compatible for python 2.6.x

### DIFF
--- a/mkcargo.py
+++ b/mkcargo.py
@@ -177,7 +177,11 @@ def exportStats():
             file = os.path.join(args.filebase,'stats_'+statSet+'.csv')
             with open(file, "wb") as csvfile:
                 writer = csv.DictWriter(csvfile, fieldnames=statsFields)
-                writer.writeheader()
+                #writer.writeheader()
+                fields = {}
+                for field in statsFields:
+                    fields[field] = field
+                writer.writerow(fields)
                 for category in includeStats[statSet]:
                     writer.writerow(stats[category])
     except ValueError:


### PR DESCRIPTION
Required for running on EMC Isilon nodes, does require manual install
of argparse.py in ‘/usr/local/lib/python2.6/site-packages/‘
